### PR TITLE
Have layer selection open when entering page

### DIFF
--- a/bundles/file-layerlist/components/MainPanel.jsx
+++ b/bundles/file-layerlist/components/MainPanel.jsx
@@ -21,7 +21,7 @@ const StyledRootEl = styled('div')`
 `;
 
 export const MainPanel = ({ layers = [], selectedLayers = [], drawControl, isDrawing }) => {
-    const [layerSelectVisible, showLayerSelect] = useState(false);
+    const [layerSelectVisible, showLayerSelect] = useState(true);
     const [basketVisible, showBasket] = useState(false);
     const isSelected = (layer) => {
         return selectedLayers.some(l => l.getId() === layer.getId());


### PR DESCRIPTION
Have selection open by default:
![image](https://user-images.githubusercontent.com/2210335/218333941-c6b9ece6-b39b-4ad9-bf6a-9bec5001f44f.png)

Instead of user having to click the Aineistot-button for getting to the selection what to download:
![image](https://user-images.githubusercontent.com/2210335/218333922-c89152e9-0e8f-412a-a3ac-3b37a97f5a0a.png)